### PR TITLE
fix: remove reject error when origin is different

### DIFF
--- a/src/tokenize/tokenize.test.ts
+++ b/src/tokenize/tokenize.test.ts
@@ -63,12 +63,12 @@ describe('tokenize', () => {
     expect(contentWindowMock.postMessage).toHaveBeenCalledTimes(1)
   })
 
-  test.skip('should ignore messages from different origins', async () => {
+  test('should ignore messages from different origins', async () => {
     const tokenize = new Tokenize(configurationsSDK)
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {})
-    const promise = tokenize.handle()
+    tokenize.handle()
 
     const messageEvent = handleCreateMessageEventMock(
       Event.Tokenize,
@@ -77,8 +77,9 @@ describe('tokenize', () => {
     )
     global.dispatchEvent(messageEvent)
 
-    await expect(promise).rejects.toThrow('Unauthorized origin')
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Unauthorized origin')
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `Unauthorized origin: https://wrong-origin.com, origin should be https://hosted-fields.malga.io`,
+    )
     expect(contentWindowMock.postMessage).toHaveBeenCalledTimes(1)
     consoleErrorSpy.mockRestore()
   })

--- a/src/tokenize/tokenize.ts
+++ b/src/tokenize/tokenize.ts
@@ -33,7 +33,10 @@ export class Tokenize {
     return new Promise((resolve, reject) => {
       const messageHandler = (event: MessageEvent<MalgaResponse>) => {
         if (!this.isValidOrigin(event.origin)) {
-          return reject(new Error('Unauthorized origin'))
+          console.error(
+            `Unauthorized origin: ${event.origin}, origin should be ${gettingOriginEvent()}`,
+          )
+          return
         }
 
         if (event.data.eventType === Event.Tokenize) {


### PR DESCRIPTION
Removendo o reject error quando a origem for diferente na função handle tokenize. 