### PR TITLE
[SDK Tokenization]: Refactor unit tests.

### DIFF
--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,3 +1,3 @@
-export const URL_HOSTED_FIELD_DEV = 'https://hosted-fields.dev.malga.io'
+export const URL_HOSTED_FIELD_DEV = 'http://localhost:5173'
 export const URL_HOSTED_FIELD_SANDBOX = 'https://hosted-fields-sandbox.malga.io'
 export const URL_HOSTED_FIELD_PROD = 'https://hosted-fields.malga.io'

--- a/src/iframes/listener.test.ts
+++ b/src/iframes/listener.test.ts
@@ -87,7 +87,7 @@ describe('listener', () => {
     },
   )
 
-  /*test('should ignore messages from incorrect origins', () => {
+  test('should ignore messages from incorrect origins', () => {
     listener()
 
     const messageHandler = addEventListenerSpy.mock.calls[0][1]
@@ -97,7 +97,7 @@ describe('listener', () => {
     messageHandler(event)
 
     expect(document.querySelector).not.toHaveBeenCalled()
-  })*/
+  })
 
   test.each`
     url                         | debug    | sandbox

--- a/src/iframes/listener.test.ts
+++ b/src/iframes/listener.test.ts
@@ -1,11 +1,19 @@
-import { handGetValidationEventData } from 'src/events'
 import { listener } from './listener'
 import { CSSClasses, Event } from 'src/enums'
 import { eventsEmitter } from 'src/tokenization'
-import { handleCreateMockEvent } from 'tests/mocks'
+import {
+  handleCreateMockEvent,
+  handleCreateMockValidityEvent,
+} from 'tests/mocks'
+import {
+  URL_HOSTED_FIELD_DEV,
+  URL_HOSTED_FIELD_PROD,
+  URL_HOSTED_FIELD_SANDBOX,
+} from 'src/constants'
 
 vi.mock('src/events', async () => {
   const actual = await vi.importActual('src/events')
+
   const actualExports =
     typeof actual === 'object' && actual !== null ? actual : {}
 
@@ -30,16 +38,19 @@ describe('listener', () => {
     parentNode = document.createElement('div')
 
     parentNode.id = 'card-number'
+
     vi.spyOn(parentNode.classList, 'toggle')
 
     document.querySelector = vi.fn((selector) => {
       if (selector === '#card-number') return parentNode
+
       return null
     })
   })
 
   afterEach(() => {
     vi.clearAllMocks()
+
     parentNode.classList.remove(CSSClasses.Focused)
   })
 
@@ -52,94 +63,151 @@ describe('listener', () => {
     )
   })
 
-  test('should get the data and type from event with correct origin', () => {
-    listener(true, false)
+  test.each`
+    url                         | debug    | sandbox
+    ${URL_HOSTED_FIELD_DEV}     | ${true}  | ${false}
+    ${URL_HOSTED_FIELD_SANDBOX} | ${false} | ${true}
+    ${URL_HOSTED_FIELD_PROD}    | ${false} | ${false}
+  `(
+    'should get the data and type from event with correct origin: $url',
+    ({ url, debug, sandbox }) => {
+      listener(debug, sandbox)
+
+      const messageHandler = addEventListenerSpy.mock.calls[0][1]
+
+      const event = handleCreateMockEvent('successOrigin', url)
+
+      messageHandler(event)
+
+      expect(document.querySelector).toHaveBeenCalledWith(
+        `#${event.data.data.field}`,
+      )
+
+      expect(document.querySelector).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  /*test('should ignore messages from incorrect origins', () => {
+    listener()
+
     const messageHandler = addEventListenerSpy.mock.calls[0][1]
 
-    const event = handleCreateMockEvent('successOrigin')
+    const event = handleCreateMockEvent('message', 'https://wrong-origin.com')
+
     messageHandler(event)
 
-    expect(document.querySelector).toHaveBeenCalledWith(
-      `#${event.data.data.field}`,
-    )
-    expect(document.querySelector).toHaveBeenCalledTimes(1)
-  })
+    expect(document.querySelector).not.toHaveBeenCalled()
+  })*/
 
-  // test('should ignore messages from incorrect origins', () => {
-  //   listener()
-  //   const messageHandler = addEventListenerSpy.mock.calls[0][1]
+  test.each`
+    url                         | debug    | sandbox
+    ${URL_HOSTED_FIELD_DEV}     | ${true}  | ${false}
+    ${URL_HOSTED_FIELD_SANDBOX} | ${false} | ${true}
+    ${URL_HOSTED_FIELD_PROD}    | ${false} | ${false}
+  `(
+    'should emit Validity event for Validity event type',
+    ({ url, debug, sandbox }) => {
+      listener(debug, sandbox)
 
-  //   const event = handleCreateMockEvent('message', 'https://wrong-origin.com')
+      const messageHandler = addEventListenerSpy.mock.calls[0][1]
 
-  //   messageHandler(event)
-  //   expect(document.querySelector).not.toHaveBeenCalled()
-  // })
+      const event = handleCreateMockValidityEvent(Event.Validity, url)
 
-  test.skip('should call validation for Validity event type', () => {
-    listener(true, false)
-    const messageHandler = addEventListenerSpy.mock.calls[0][1]
+      messageHandler(event)
 
-    const event = handleCreateMockEvent(Event.Validity)
+      console.log('event data', event)
 
-    messageHandler(event)
-    expect(handGetValidationEventData).toHaveBeenCalledWith(
-      event.data.data.field,
-      expect.any(Element),
-    )
-  })
+      expect(eventsEmitter.emit).toHaveBeenCalledWith('validity', {
+        field: event.data.data.field,
+        valid: event.data.data.valid,
+        empty: event.data.data.empty,
+        potentialValid: event.data.data.potentialValid,
+        parentNode: expect.any(Element),
+      })
+    },
+  )
 
-  test('should emit CardTypeChanged event for CardTypeChanged event type', () => {
-    listener(true, false)
-    const messageHandler = addEventListenerSpy.mock.calls[0][1]
-    const event = handleCreateMockEvent(Event.CardTypeChanged)
+  test.each`
+    url                         | debug    | sandbox
+    ${URL_HOSTED_FIELD_DEV}     | ${true}  | ${false}
+    ${URL_HOSTED_FIELD_SANDBOX} | ${false} | ${true}
+    ${URL_HOSTED_FIELD_PROD}    | ${false} | ${false}
+  `(
+    'should emit CardTypeChanged event for CardTypeChanged event type',
+    ({ url, debug, sandbox }) => {
+      listener(debug, sandbox)
 
-    const updateEvent = {
-      ...event,
-      data: {
-        ...event.data,
+      const messageHandler = addEventListenerSpy.mock.calls[0][1]
+
+      const event = handleCreateMockEvent(Event.CardTypeChanged, url)
+
+      const updateEvent = {
+        ...event,
         data: {
-          ...event.data.data,
-          card: 'visa',
+          ...event.data,
+          data: {
+            ...event.data.data,
+            card: 'visa',
+          },
         },
-      },
-    }
+      }
 
-    messageHandler(updateEvent)
+      messageHandler(updateEvent)
 
-    expect(eventsEmitter.emit).toHaveBeenCalledWith('cardTypeChanged', {
-      card: 'visa',
-      parentNode: expect.any(Element),
-      field: 'card-number',
-    })
-  })
+      expect(eventsEmitter.emit).toHaveBeenCalledWith('cardTypeChanged', {
+        card: 'visa',
+        parentNode: expect.any(Element),
+        field: 'card-number',
+      })
+    },
+  )
 
-  test('should emit Focus event for Focus event type', () => {
-    listener(true, false)
-    const messageHandler = addEventListenerSpy.mock.calls[0][1]
+  test.each`
+    url                         | debug    | sandbox
+    ${URL_HOSTED_FIELD_DEV}     | ${true}  | ${false}
+    ${URL_HOSTED_FIELD_SANDBOX} | ${false} | ${true}
+    ${URL_HOSTED_FIELD_PROD}    | ${false} | ${false}
+  `(
+    'should emit Focus event for Focus event type',
+    ({ url, debug, sandbox }) => {
+      listener(debug, sandbox)
 
-    const event = handleCreateMockEvent(Event.Focus)
+      const messageHandler = addEventListenerSpy.mock.calls[0][1]
 
-    messageHandler(event)
-    expect(eventsEmitter.emit).toHaveBeenCalledWith('focus', {
-      field: 'card-number',
-      parentNode: expect.any(Element),
-    })
-    expect(parentNode.classList.contains(CSSClasses.Focused)).toBe(true)
-  })
+      const event = handleCreateMockEvent(Event.Focus, url)
 
-  test('should emit Blur event for Blur event type', () => {
+      messageHandler(event)
+
+      expect(eventsEmitter.emit).toHaveBeenCalledWith('focus', {
+        field: 'card-number',
+        parentNode: expect.any(Element),
+      })
+
+      expect(parentNode.classList.contains(CSSClasses.Focused)).toBe(true)
+    },
+  )
+
+  test.each`
+    url                         | debug    | sandbox
+    ${URL_HOSTED_FIELD_DEV}     | ${true}  | ${false}
+    ${URL_HOSTED_FIELD_SANDBOX} | ${false} | ${true}
+    ${URL_HOSTED_FIELD_PROD}    | ${false} | ${false}
+  `('should emit Blur event for Blur event type', ({ url, debug, sandbox }) => {
     parentNode.classList.add(CSSClasses.Focused)
 
-    listener(true, false)
+    listener(debug, sandbox)
+
     const messageHandler = addEventListenerSpy.mock.calls[0][1]
 
-    const event = handleCreateMockEvent(Event.Blur)
+    const event = handleCreateMockEvent(Event.Blur, url)
 
     messageHandler(event)
+
     expect(eventsEmitter.emit).toHaveBeenCalledWith('blur', {
       field: 'card-number',
       parentNode: expect.any(Element),
     })
+
     expect(parentNode.classList.contains(CSSClasses.Focused)).toBe(false)
   })
 })

--- a/src/tokenize/tokenize.test.ts
+++ b/src/tokenize/tokenize.test.ts
@@ -63,12 +63,12 @@ describe('tokenize', () => {
     expect(contentWindowMock.postMessage).toHaveBeenCalledTimes(1)
   })
 
-  test.skip('should ignore messages from different origins', async () => {
+  test('should ignore messages from different origins', async () => {
     const tokenize = new Tokenize(configurationsSDK)
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {})
-    const promise = tokenize.handle()
+    tokenize.handle()
 
     const messageEvent = handleCreateMessageEventMock(
       Event.Tokenize,
@@ -77,8 +77,9 @@ describe('tokenize', () => {
     )
     global.dispatchEvent(messageEvent)
 
-    await expect(promise).rejects.toThrow('Unauthorized origin')
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Unauthorized origin')
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `Unauthorized origin: https://wrong-origin.com, origin should be https://hosted-fields.malga.io`,
+    )
     expect(contentWindowMock.postMessage).toHaveBeenCalledTimes(1)
     consoleErrorSpy.mockRestore()
   })

--- a/src/tokenize/tokenize.ts
+++ b/src/tokenize/tokenize.ts
@@ -33,7 +33,10 @@ export class Tokenize {
     return new Promise((resolve, reject) => {
       const messageHandler = (event: MessageEvent<MalgaResponse>) => {
         if (!this.isValidOrigin(event.origin)) {
-          return reject(new Error('Unauthorized origin'))
+          console.error(
+            `Unauthorized origin: ${event.origin}, origin should be ${gettingOriginEvent()}`,
+          )
+          return
         }
 
         if (event.data.eventType === Event.Tokenize) {

--- a/tests/mocks/common-configurations.ts
+++ b/tests/mocks/common-configurations.ts
@@ -43,3 +43,12 @@ export const configurationWithSubmitData = {
     debug: undefined,
   },
 }
+
+export const configSDKEachEnvironment = (debug: boolean, sandbox: boolean) => ({
+  ...configurationsSDK,
+  options: {
+    ...configurationsSDK.options,
+    ...(debug && { debug: true }),
+    ...(sandbox && { sandbox: true }),
+  },
+})

--- a/tests/mocks/events.ts
+++ b/tests/mocks/events.ts
@@ -1,6 +1,6 @@
-export function handleCreateMockEvent(eventType: string, origin?: string) {
+export function handleCreateMockEvent(eventType: string, origin: string) {
   const eventMocked = {
-    origin: origin ?? 'https://hosted-fields.dev.malga.io',
+    origin: origin,
     data: {
       eventType: eventType,
       data: {
@@ -14,10 +14,10 @@ export function handleCreateMockEvent(eventType: string, origin?: string) {
 
 export function handleCreateMockValidityEvent(
   eventType: string,
-  origin?: string,
+  origin: string,
 ) {
   const eventMocked = {
-    origin: origin ?? 'https://hosted-fields.dev.malga.io',
+    origin: origin,
     data: {
       eventType: eventType,
       data: {
@@ -34,11 +34,11 @@ export function handleCreateMockValidityEvent(
 
 export function handleCreateMessageEventMock(
   eventType: string,
+  origin: string,
   tokenId?: string,
-  origin?: string,
 ) {
   const messageEvent = new MessageEvent('message', {
-    origin: origin ?? 'https://hosted-fields.dev.malga.io',
+    origin: origin,
     data: {
       eventType: eventType,
       data: {

--- a/tests/mocks/events.ts
+++ b/tests/mocks/events.ts
@@ -12,6 +12,26 @@ export function handleCreateMockEvent(eventType: string, origin?: string) {
   return eventMocked
 }
 
+export function handleCreateMockValidityEvent(
+  eventType: string,
+  origin?: string,
+) {
+  const eventMocked = {
+    origin: origin ?? 'https://hosted-fields.dev.malga.io',
+    data: {
+      eventType: eventType,
+      data: {
+        field: 'card-number',
+        valid: true,
+        empty: false,
+        potentialValid: false,
+      },
+    },
+  }
+
+  return eventMocked
+}
+
 export function handleCreateMessageEventMock(
   eventType: string,
   tokenId?: string,


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)

Para as melhorias de debug, nós conseguimos fazer o hosted-fields  ser exposto localmente e assim, inserir a url local dele no SDK. 

Com isso, percebi que em alguns testes unitários, tinhamos a url do hf chumbada, de forma que só executaria pra um ambiente (https://hosted-fields.dev.malga.io). 

## Proposed solution (including technical details and their motivations)

Para melhorar a abrangência dos testes, estou executando test.each de forma que um mesmo teste seja executado em mais de um ambiente do hf. 

Também corrigi um teste do evento de validação criando um mock a mais específic pra mensagem dele. 

## Observations (optional - any additional information you deem important)

Coloquei a url local no url.ts mas podemos deixar o de dev e mudar só quando o dev quiser.

