### PR TITLE
fix: error response type

### DIFF
--- a/.changeset/forty-moose-itch.md
+++ b/.changeset/forty-moose-itch.md
@@ -1,0 +1,5 @@
+---
+'@malga/tokenization': minor
+---
+
+fixing error return object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malga/tokenization",
-  "version": "2.2.7",
+  "version": "2.3.0",
   "packageManager": "pnpm@9.0.5",
   "description": "Simple way to tokenize cards with Malga",
   "repository": "git@github.com:plughacker/malga-tokenization.git",

--- a/src/interfaces/tokenize.ts
+++ b/src/interfaces/tokenize.ts
@@ -30,15 +30,13 @@ type MalgaErrorDeclinedCode =
   | 'transaction_not_allowed'
   | 'try_again'
 
-export interface MalgaErrorResponse {
-  error: {
+  export interface MalgaErrorResponse {
     type: MalgaErrorType
     code: number
     message: string
     details?: string | string[]
     declinedCode?: MalgaErrorDeclinedCode
   }
-}
 
 export interface MalgaPayloadResponse {
   tokenId: string


### PR DESCRIPTION
Só alterando o tipo do MalgaResponseError pra bater com o tipo do hosted-fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small TypeScript interface change that adjusts error payload typing; low risk but may surface compile-time mismatches where the old nested `error` shape was assumed.
> 
> **Overview**
> Updates `MalgaErrorResponse` in `src/interfaces/tokenize.ts` to **remove the nested `error` object** and expose `type`, `code`, `message`, `details`, and `declinedCode` at the top level, aligning the type with the hosted-fields error format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e340721160974992670761fc2349dbc7fc56a47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->